### PR TITLE
Fixed RampForce effect in Direct Input

### DIFF
--- a/source/directinput/RampForce.cpp
+++ b/source/directinput/RampForce.cpp
@@ -50,7 +50,7 @@ namespace DirectInput
 
 	int RampForce::Size::get()
 	{
-		return sizeof( DICONSTANTFORCE );
+		return sizeof( DIRAMPFORCE );
 	}
 
 	void *RampForce::ToUnmanaged()


### PR DESCRIPTION
After like 10 years, a lot of human DNA gossip that it is not working and nobody care to read up the docs or just open two SlimDX files and compare :-) ...so it works now. I have recompiled it on Windows XP. Very good project! For retrogaming, uber! And hats down for .NET 2.0 support. That means it will work even on Windows 98 SE!